### PR TITLE
Fix observer pattern and warehouse update method

### DIFF
--- a/shapes/src/main/java/lt/esdc/shapes/entity/Shape.java
+++ b/shapes/src/main/java/lt/esdc/shapes/entity/Shape.java
@@ -1,10 +1,16 @@
 package lt.esdc.shapes.entity;
 
-import lt.esdc.shapes.observer.ShapeObserver;
+import lt.esdc.shapes.observer.ShapeSubject;
 
-public abstract class Shape {
+/**
+ * Base class for all shapes.
+ *
+ * <p>It now extends {@link ShapeSubject} so that each shape can have
+ * multiple observers.  Previous implementation supported only a single
+ * observer which did not align with the tests.</p>
+ */
+public abstract class Shape extends ShapeSubject {
     private String id;
-    private ShapeObserver observer;
 
     public Shape(String id) {
         this.id = id;
@@ -18,12 +24,8 @@ public abstract class Shape {
         this.id = id;
     }
 
-    public void setObserver(ShapeObserver observer) {
-        this.observer = observer;
-    }
-
     protected void notifyObserver() {
-        if (observer != null) observer.onShapeChanged(this.id, this);
+        notifyObservers(this);
     }
 
     public abstract double calculateArea();

--- a/shapes/src/main/java/lt/esdc/shapes/observer/ShapeObserver.java
+++ b/shapes/src/main/java/lt/esdc/shapes/observer/ShapeObserver.java
@@ -2,6 +2,20 @@ package lt.esdc.shapes.observer;
 
 import lt.esdc.shapes.entity.Shape;
 
+/**
+ * Observer interface for shapes.
+ *
+ * <p>The tests in this project expect observers to receive only the
+ * updated shape instance.  Previously the interface provided the shape
+ * identifier as a separate argument.  This mismatched the tests and lead
+ * to compilation errors.  The method signature has been adjusted to
+ * match the expectation.</p>
+ */
 public interface ShapeObserver {
-    void onShapeChanged(String shapeId, Shape shape);
+    /**
+     * Called when a shape changes.
+     *
+     * @param shape the shape that has been modified
+     */
+    void update(Shape shape);
 }

--- a/shapes/src/main/java/lt/esdc/shapes/observer/ShapeSubject.java
+++ b/shapes/src/main/java/lt/esdc/shapes/observer/ShapeSubject.java
@@ -23,9 +23,9 @@ public class ShapeSubject {
         observers.remove(observer);
     }
     
-    public void notifyObservers(String shapeId, Shape shape) {
+    public void notifyObservers(Shape shape) {
         for (ShapeObserver observer : observers) {
-            observer.onShapeChanged(shapeId, shape);
+            observer.update(shape);
         }
     }
 }

--- a/shapes/src/main/java/lt/esdc/shapes/service/RectangleService.java
+++ b/shapes/src/main/java/lt/esdc/shapes/service/RectangleService.java
@@ -7,7 +7,16 @@ import lt.esdc.shapes.warehouse.ShapeWarehouse;
 public class RectangleService implements ShapeService<Rectangle> {
     
     private final ShapeWarehouse warehouse;
-    
+
+    /**
+     * Creates a service using the default {@link ShapeWarehouse} instance.
+     * This constructor is primarily used in tests where a simplified
+     * setup is required.
+     */
+    public RectangleService() {
+        this(ShapeWarehouse.getInstance());
+    }
+
     public RectangleService(ShapeWarehouse warehouse) {
         this.warehouse = warehouse;
     }

--- a/shapes/src/main/java/lt/esdc/shapes/warehouse/ShapeWarehouse.java
+++ b/shapes/src/main/java/lt/esdc/shapes/warehouse/ShapeWarehouse.java
@@ -39,12 +39,12 @@ public class ShapeWarehouse implements ShapeObserver {
         areaMap.put(shapeId, area);
     }
     
-    public Double getPerimeter(String shapeId) {
-        return perimeterMap.get(shapeId);
+    public double getPerimeter(String shapeId) {
+        return perimeterMap.getOrDefault(shapeId, 0.0);
     }
-    
-    public Double getArea(String shapeId) {
-        return areaMap.get(shapeId);
+
+    public double getArea(String shapeId) {
+        return areaMap.getOrDefault(shapeId, 0.0);
     }
     
     public void clear() {
@@ -53,14 +53,14 @@ public class ShapeWarehouse implements ShapeObserver {
     }
     
     @Override
-    public void onShapeChanged(String shapeId, Shape shape) {
+    public void update(Shape shape) {
         if (rectangleService != null && shape instanceof Rectangle) {
             Rectangle rectangle = (Rectangle) shape;
-            double perimeter = rectangle.calculatePerimeter();
-            double area = rectangle.calculateArea();
-            
-            storePerimeter(shapeId, perimeter);
-            storeArea(shapeId, area);
+            double perimeter = rectangleService.calculatePerimeter(rectangle);
+            double area = rectangleService.calculateArea(rectangle);
+
+            storePerimeter(rectangle.getId(), perimeter);
+            storeArea(rectangle.getId(), area);
         }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `ShapeObserver` interface to accept just a Shape
- update `ShapeSubject` and `Shape` to support the new observer API
- add default constructor for `RectangleService`
- return 0 for unknown shapes and implement update in `ShapeWarehouse`

## Testing
- `javac -cp shapes/src/main/java shapes/src/main/java/lt/esdc/shapes/observer/ShapeObserver.java shapes/src/main/java/lt/esdc/shapes/entity/Shape.java shapes/src/main/java/lt/esdc/shapes/observer/ShapeSubject.java shapes/src/main/java/lt/esdc/shapes/warehouse/ShapeWarehouse.java shapes/src/main/java/lt/esdc/shapes/service/RectangleService.java`

------
https://chatgpt.com/codex/tasks/task_e_683eed12601c8328848b15b07ac98c52